### PR TITLE
Added pkg-config file generation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -33,3 +33,14 @@ subdir('assets/static')
 subdir('src')
 subdir('tests')
 
+pkg = import('pkgconfig')
+pkg.generate(
+    name: 'libconstants',
+    description: 'Physical Constants for SERiF and related projects',
+    version: meson.project_version(),
+    libraries: [libconst],
+    subdirs: ['libconstants'],
+    filebase: 'libconstants',
+    install_dir: join_paths(get_option('libdir'), 'pkgconfig')
+)
+

--- a/readme.md
+++ b/readme.md
@@ -3,3 +3,21 @@
 libconstants is the authoritative source for physical constants for the SERiF project.
 
 This has been broken out of the main serif project to allow for more modularity
+
+## Building
+In order to build libconstants you need `meson>=1.5.0`. This can be installed with `pip`
+
+```bash
+pip install "meson>=1.5.0"
+```
+
+Then from the root libconstants directory it is as simple as
+
+```bash
+meson setup build --buildtype=release
+meson compile -C build
+meson test -C build
+```
+
+this will auto generate a pkg-config file for you so that linking other libraries to libconstants is easy.
+


### PR DESCRIPTION
libconstants is now more or less stable. SERiF and other projects can link against it.